### PR TITLE
feat: take env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ services:
     image: ghcr.io/s0up4200/redactedhook:latest
     user: 1000:1000
     #environment:
-    #  - SERVER_ADDRESS=0.0.0.0 # binds to 0.0.0.0 by default
+    #  - SERVER_ADDRESS=0.0.0.0 # binds to 127.0.0.1 by default
     #  - SERVER_PORT=42135 # defaults to 42135
     ports:
       - "42135:42135"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ To run RedactedHook, you'll need:
 docker pull ghcr.io/s0up4200/redactedhook:latest
 ```
 
+**docker compose**
+
+```docker
+version: "3.7"
+services:
+  redactedhook:
+    container_name: redactedhook
+    image: ghcr.io/s0up4200/redactedhook:latest
+    user: 1000:1000
+    network_mode: host
+```
+
 #### Using precompiled binaries
 
 Download the appropriate binary for your platform from the [releases](https://github.com/s0up4200/RedactedHook/releases/latest) page.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ services:
     container_name: redactedhook
     image: ghcr.io/s0up4200/redactedhook:latest
     user: 1000:1000
-    network_mode: host
+    #environment:
+    #  - SERVER_ADDRESS=0.0.0.0 # binds to 0.0.0.0 by default
+    #  - SERVER_PORT=42135 # defaults to 42135
+    ports:
+      - "42135:42135"
 ```
 
 #### Using precompiled binaries

--- a/distrib/systemd/redactedhook@.service
+++ b/distrib/systemd/redactedhook@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=redactedhook service for %i
+After=syslog.target network-online.target
+
+[Service]
+Type=simple
+User=%i
+Group=%i
+ExecStart=/usr/bin/redactedhook
+
+[Install]
+WantedBy=multi-user.target

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     container_name: redactedhook
     image: ghcr.io/s0up4200/redactedhook:latest
     user: 1000:1000
-    #environment:
-    #  - SERVER_ADDRESS=0.0.0.0 # binds to 0.0.0.0 by default
-    #  - SERVER_PORT=42135 # defaults to 42135
+    environment:
+      - SERVER_ADDRESS=0.0.0.0 # binds to 127.0.0.1 by default
+      - SERVER_PORT=42135 # defaults to 42135
     ports:
       - "42135:42135"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.7"
+services:
+  redactedhook:
+    container_name: redactedhook
+    image: ghcr.io/s0up4200/redactedhook:latest
+    user: 1000:1000
+    network_mode: host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,4 +4,8 @@ services:
     container_name: redactedhook
     image: ghcr.io/s0up4200/redactedhook:latest
     user: 1000:1000
-    network_mode: host
+    #environment:
+    #  - SERVER_ADDRESS=0.0.0.0 # binds to 0.0.0.0 by default
+    #  - SERVER_PORT=42135 # defaults to 42135
+    ports:
+      - "42135:42135"

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func main() {
 
 	address := os.Getenv("SERVER_ADDRESS")
 	if address == "" {
-		address = "0.0.0.0"
+		address = "127.0.0.1"
 	}
 	port := os.Getenv("SERVER_PORT")
 	if port == "" {

--- a/main.go
+++ b/main.go
@@ -34,14 +34,25 @@ type ResponseData struct {
 }
 
 func main() {
-	// Configure zerolog to use colored output
 	zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: "2006-01-02 15:04:05", NoColor: false})
 
 	http.HandleFunc("/redacted/ratio", checkRatio)
 	http.HandleFunc("/redacted/uploader", checkUploader)
-	log.Info().Msg("Starting server on 127.0.0.1:42135")
-	err := http.ListenAndServe("127.0.0.1:42135", nil)
+
+	address := os.Getenv("SERVER_ADDRESS")
+	if address == "" {
+		address = "0.0.0.0"
+	}
+	port := os.Getenv("SERVER_PORT")
+	if port == "" {
+		port = "42135"
+	}
+
+	// Start the server
+	serverAddr := address + ":" + port
+	log.Info().Msg("Starting server on " + serverAddr)
+	err := http.ListenAndServe(serverAddr, nil)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to start server")
 	}


### PR DESCRIPTION
It will bind to 127.0.0.1 by default, but docker folks can do like this:

```
version: "3.7"
services:
  redactedhook:
    container_name: redactedhook
    image: ghcr.io/s0up4200/redactedhook:latest
    user: 1000:1000
    environment:
      - SERVER_ADDRESS=0.0.0.0
      - SERVER_PORT=42135
    ports:
      - "42135:42135"
```