### PR TITLE
Remove "," in json of minimum required data

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ curl -X POST \
 ```json
 {
     "torrent_id": {{.TorrentID}},
-    "indexer": "{{ .Indexer | js }}",
+    "indexer": "{{ .Indexer | js }}"
 }
 ```
 


### PR DESCRIPTION
This "," has cost me a lot of time because I copied from there into autobrr. I think this might be a comon mistake that people make.
So I propose that the "," is removed.
Autobrr gets this in the log if you have a "," there.
`filter external webhook response status: 400 body: invalid JSON payload module=filter`
Thank you!